### PR TITLE
Bad performance on mobile in "Dance Recording" mode.

### DIFF
--- a/src/containers/Tutorial/index.js
+++ b/src/containers/Tutorial/index.js
@@ -66,9 +66,8 @@ export default class Tutorial extends Component {
   }
 
   async performAddPerformance() {
-    if (!viewer.vrEffect.isPresenting) {
-      await viewer.vrEffect.requestPresent();
-    }
+    await viewer.enterPresent();
+
     // Wait for the VR overlay to cover the screen:
     await sleep(500);
     this.props.goto('record');


### PR DESCRIPTION
Fixing incorrect enter VR for dance recording: need to use viewer.enterPresent() thus the noSleep video will be correctly stopped and will not consume GPU resources on its decoding. If noSleep video is not
stopped then performance in VR on mobile is really bad.